### PR TITLE
17 Metadata and Docstrings

### DIFF
--- a/src/dev/chrisreyes/task_tracker/core.clj
+++ b/src/dev/chrisreyes/task_tracker/core.clj
@@ -15,7 +15,13 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with Task Tracker.  If not, see <https://www.gnu.org/licenses/>.
 
-(ns dev.chrisreyes.task-tracker.core
+(ns
+  ^{:author "Christopher R. Reyes"}
+  dev.chrisreyes.task-tracker.core
+  "Here we coordinate between the different layers of the app.
+  Eventually, this namespace will be responsible for allowing
+  end-users to interact with the system by creating, reading,
+  updating, and deleting tasks."
   (:gen-class)
   (:require [dev.chrisreyes.task-tracker.hierarchy :as hierarchy]
             [dev.chrisreyes.task-tracker.persistence :as persistence]))

--- a/src/dev/chrisreyes/task_tracker/hierarchy.clj
+++ b/src/dev/chrisreyes/task_tracker/hierarchy.clj
@@ -15,7 +15,12 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with Task Tracker.  If not, see <https://www.gnu.org/licenses/>.
 
-(ns dev.chrisreyes.task-tracker.hierarchy
+(ns
+  ^{:author "Christopher R. Reyes"}
+  dev.chrisreyes.task-tracker.hierarchy
+  "This is a collection of operations for working with hierarchical data.
+  This is based on https://arxiv.org/pdf/0806.3115.pdf.
+  Hazel, Dan. \"Using rational numbers to key nested sets.\" arXiv preprint arXiv:0806.3115 (2008)."
   (:gen-class))
 
 (defn create-root

--- a/src/dev/chrisreyes/task_tracker/persistence.clj
+++ b/src/dev/chrisreyes/task_tracker/persistence.clj
@@ -15,7 +15,12 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with Task Tracker.  If not, see <https://www.gnu.org/licenses/>.
 
-(ns dev.chrisreyes.task-tracker.persistence
+(ns
+  ^{:author "Christopher R. Reyes"}
+  dev.chrisreyes.task-tracker.persistence
+  "These are functions for working with a postgres database.
+  They provide CRUD operations for our model types in
+  persistent storage."
   (:gen-class)
   (:require [cheshire.core :as json]
             [clojure.java.jdbc :as jdbc]

--- a/src/dev/chrisreyes/task_tracker/spec.clj
+++ b/src/dev/chrisreyes/task_tracker/spec.clj
@@ -15,9 +15,12 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with Task Tracker.  If not, see <https://www.gnu.org/licenses/>.
 
-(ns ^{:author "Christopher R Reyes"
-      :doc "Optional specifications for use with Clojure 1.9 or later."}
+(ns
+  ^{:author "Christopher R Reyes"}
   dev.chrisreyes.task-tracker.spec
+  "These optional specifications are for use with Clojure 1.9 or later.
+  They describe the contents of the various maps that are passed around
+  the application."
   (:require [clojure.spec.alpha :as spec]
             [dev.chrisreyes.task-tracker.hierarchy :as hierarchy]))
 

--- a/test/dev/chrisreyes/task_tracker/core_test.clj
+++ b/test/dev/chrisreyes/task_tracker/core_test.clj
@@ -15,7 +15,9 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with Task Tracker.  If not, see <https://www.gnu.org/licenses/>.
 
-(ns dev.chrisreyes.task-tracker.core-test
+(ns
+  ^{:author "Christopher R. Reyes"}
+  dev.chrisreyes.task-tracker.core-test
   (:require [clojure.test :refer :all]
             [dev.chrisreyes.task-tracker.core :refer :all]))
 

--- a/test/dev/chrisreyes/task_tracker/hierarchy_test.clj
+++ b/test/dev/chrisreyes/task_tracker/hierarchy_test.clj
@@ -15,7 +15,9 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with Task Tracker.  If not, see <https://www.gnu.org/licenses/>.
 
-(ns dev.chrisreyes.task-tracker.hierarchy-test
+(ns
+  ^{:author "Christopher R. Reyes"}
+  dev.chrisreyes.task-tracker.hierarchy-test
   (:require [clojure.test :refer :all]
             [dev.chrisreyes.task-tracker.hierarchy :refer :all]))
 

--- a/test/dev/chrisreyes/task_tracker/persistence_test.clj
+++ b/test/dev/chrisreyes/task_tracker/persistence_test.clj
@@ -15,7 +15,9 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with Task Tracker.  If not, see <https://www.gnu.org/licenses/>.
 
-(ns dev.chrisreyes.task-tracker.persistence-test
+(ns
+  ^{:author "Christopher R. Reyes"}
+  dev.chrisreyes.task-tracker.persistence-test
   (:require [clojure.java.jdbc :as jdbc]
             [clojure.test :refer :all]
             [dev.chrisreyes.task-tracker.persistence :as persistence]))


### PR DESCRIPTION
See #17 

Added the `:author` metadata tag and docstrings to every non-test namespace.

I initially added docstrings to the test namespaces as well, but found that they didn't really add any information. It was relatively obvious which namespace was being tested by each test namespace given its name.