### PR TITLE
12 delete task

### DIFF
--- a/resources/migrations/postgres/v00_01_01-05-cascading-deletes.sql
+++ b/resources/migrations/postgres/v00_01_01-05-cascading-deletes.sql
@@ -1,0 +1,30 @@
+/* Copyright (C) 2019  Christopher R. Reyes
+ *
+ * This file is part of Task Tracker.
+ *
+ * Task Tracker is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Task Tracker is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Task Tracker.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Updates the unique constraint from task to hierarchy to cascade 
+ * deletes. This way when the task is deleted, the associated
+ * hierarchy is also deleted automatically.
+ */
+
+alter table task
+drop constraint task_hierarchy_id_fkey,
+add constraint task_hierarchy_id_fkey
+    foreign key (hierarchy_id)
+    references hierarchy (hierarchy_id)
+    on delete cascade;

--- a/src/dev/chrisreyes/task_tracker/persistence.clj
+++ b/src/dev/chrisreyes/task_tracker/persistence.clj
@@ -206,15 +206,14 @@
 
 (defn remove-task
   "Deletes a particular task by task ID, returning the number of rows deleted."
-  [db-config task-id username]
+  [db-config task-id]
   (jdbc/delete! db-config
                 :task
                 ["task_id = ?", task-id]))
 
-
 (defn remove-subtasks
   "Deletes all subtasks of a particular task, returning the number of subtasks deleted."
-  [db-config parent-task-id username]
+  [db-config parent-task-id]
   (jdbc/execute! db-config
                  ["delete
                    from

--- a/src/dev/chrisreyes/task_tracker/persistence.clj
+++ b/src/dev/chrisreyes/task_tracker/persistence.clj
@@ -203,3 +203,10 @@
                                 hierarchy.next_sibling_denominator,
                                 hierarchy.next_sibling_numerator,
                                 hierarchy.numerator")))
+
+(defn remove-task
+  "Deletes a particular task by task ID, returning the number of rows deleted."
+  [db-config task-id username]
+  (jdbc/delete! db-config
+                :task
+                ["task_id = ?", task-id]))

--- a/src/dev/chrisreyes/task_tracker/persistence.clj
+++ b/src/dev/chrisreyes/task_tracker/persistence.clj
@@ -210,3 +210,27 @@
   (jdbc/delete! db-config
                 :task
                 ["task_id = ?", task-id]))
+
+
+(defn remove-subtasks
+  "Deletes all subtasks of a particular task, returning the number of subtasks deleted."
+  [db-config parent-task-id username]
+  (jdbc/execute! db-config
+                 ["delete
+                   from
+                     task
+                   where
+                     task.task_id in (
+                       select
+                         subtask.task_id
+                       from
+                         task parent
+                         join hierarchy
+                           on parent = hierarchy.hierarchy_id
+                         left outer join hierarchy subtask_hierarchy
+                           on is_subtask(hierarchy, subtask_hierarchy)
+                         join task subtask
+                           on subtask.hierarchy_id = subtask_hierarchy.hierarchy_id
+                       where
+                         parent.task_id = ?)"
+                  parent-task-id]))

--- a/src/dev/chrisreyes/task_tracker/persistence.clj
+++ b/src/dev/chrisreyes/task_tracker/persistence.clj
@@ -225,7 +225,7 @@
                        from
                          task parent
                          join hierarchy
-                           on parent = hierarchy.hierarchy_id
+                           on parent.hierarchy_id = hierarchy.hierarchy_id
                          left outer join hierarchy subtask_hierarchy
                            on is_subtask(hierarchy, subtask_hierarchy)
                          join task subtask

--- a/test/dev/chrisreyes/task_tracker/persistence_test.clj
+++ b/test/dev/chrisreyes/task_tracker/persistence_test.clj
@@ -250,9 +250,3 @@
                 (str "Should have preserved the "
                      prop
                      " property in the original task"))))))))
-
-(deftest delete-task-test
-  (testing "Can delete a task from persistent storage"
-    (with-redefs [jdbc/db-transaction* (fn [config f] (f config))
-                  persistence/remove-task (fn [_ task _] task)]
-      (print "todo"))))

--- a/test/dev/chrisreyes/task_tracker/persistence_test.clj
+++ b/test/dev/chrisreyes/task_tracker/persistence_test.clj
@@ -250,3 +250,9 @@
                 (str "Should have preserved the "
                      prop
                      " property in the original task"))))))))
+
+(deftest delete-task-test
+  (testing "Can delete a task from persistent storage"
+    (with-redefs [jdbc/db-transaction* (fn [config f] (f config))
+                  persistence/remove-task (fn [_ task _] task)]
+      (print "todo"))))


### PR DESCRIPTION
Addresses #12 

Changes:
- Updated the schema to cascade deletes from `task` table to the associated `hierarchy` node.
- Created a function to delete a task by ID
- Created a function to delete all subtasks of a task by ID

NOTE: The database migration is only run if there is no existing postgres data. If you already have data, you can run the migration yourself with:
- `docker-compose exec postgres psql` to start up psql attached to the docker container
- `\i /docker-entrypoint-initdb.d/v00_01_01-05-cascading-deletes.sql` to run the new migration

Test by:
- Create a task with many subtasks
   - We'll call the ID of that parent task `parent-task-id` below
- Call `(persistence/remove-subtasks db-config parent-task-id)`
   - See that all of the subtasks are deleted from the `task` table
   - See that their associated rows are deleted from the `hierarchy` table
- Call `(persistence/remove-task db-config parent-task-id)`
   - See that the task is deleted from the `task` table
   - See that the associated row is deleted from the `hierarchy` table