### PR TITLE
#7 - Aggregating child timing estimates

### DIFF
--- a/src/dev/chrisreyes/task_tracker/core.clj
+++ b/src/dev/chrisreyes/task_tracker/core.clj
@@ -26,6 +26,73 @@
   (:require [dev.chrisreyes.task-tracker.hierarchy :as hierarchy]
             [dev.chrisreyes.task-tracker.persistence :as persistence]))
 
+
+(defn -db-config
+  "Gets the default db-config"
+  []
+  (persistence/get-config
+    (persistence/get-secret-from-aws
+      (persistence/get-credentials-secret))))
+
+(defn -add-subtasks
+  "Adds n children tasks to a parent task"
+  ([root-task]
+   (-add-subtasks root-task 3))
+  ([root-task n]
+   (let [db-config (-db-config)]
+     (reduce (fn [root i] (let [child-hierarchy-data (hierarchy/add-child
+                                                      (:hierarchy-node root))
+                                child-hierarchy (:child child-hierarchy-data)
+                                updated-root-hierarchy (:hierarchy-node child-hierarchy-data)
+                                child-task {:hierarchy-node child-hierarchy
+                                            :issue-link (str (inc i)
+                                                             "th Child of "
+                                                             n
+                                                             " for task "
+                                                             (:task-id root))
+                                            :estimated-time-minutes (* 10 (inc i))}]
+                            (persistence/save-task db-config child-task (System/getenv "USER"))
+                            (assoc root :hierarchy-node updated-root-hierarchy)))
+             root-task
+             (range n)))))
+
+(defn -add-nested-subtasks
+  "Adds n successive subtasks to a task such that each subtask is a parent of the next subtask added"
+  ([root-task]
+   (-add-nested-subtasks root-task 3))
+  ([root-task n]
+   (let [db-config (-db-config)]
+     (reduce (fn [root i] (let [child-hierarchy-data (hierarchy/add-child
+                                                      (:hierarchy-node root))
+                                child-hierarchy (:child child-hierarchy-data)
+                                child-task {:hierarchy-node child-hierarchy
+                                            :issue-link (str (inc i)
+                                                             "th Recursive Child of "
+                                                             n
+                                                             " for task "
+                                                             (:task-id root-task))
+                                            :estimated-time-minutes (* 10 (inc i))}]
+                            (persistence/save-task db-config child-task (System/getenv "USER"))))
+             root-task
+             (range n)))))
+
+(defn -create-task-with-subtasks
+  "Creates a single task with n children"
+  ([]
+   (-create-task-with-subtasks 3))
+  ([n]
+   (let [db-config (-db-config)
+         root-numerator (persistence/get-next-root db-config)
+         root-hierarchy (hierarchy/create-root root-numerator)
+         root-task (persistence/save-task db-config
+                                          {:hierarchy-node root-hierarchy
+                                           :issue-link (str "Hello "
+                                                            root-numerator
+                                                            " Parent!")
+                                           :estimated-time-minutes 10}
+                                          (System/getenv "USER"))]
+     (-add-subtasks root-task n))))
+
 (defn -main
   "I don't do a whole lot ... yet."
   [& args]

--- a/src/dev/chrisreyes/task_tracker/persistence.clj
+++ b/src/dev/chrisreyes/task_tracker/persistence.clj
@@ -184,13 +184,17 @@
                                 hierarchy.next_sibling_denominator,
                                 hierarchy.next_sibling_numerator,
                                 hierarchy.numerator,
-                                count(subtask.hierarchy_id) as num_children
+                                count(subhierarchy.hierarchy_id) as num_children,
+                                sum(subtask.estimated_time_minutes) as children_estimated_time_minutes,
+                                sum(subtask.actual_time_minutes) as children_actual_time_minutes
                               from
                                 hierarchy
                                 join task
                                   on hierarchy.hierarchy_id = task.hierarchy_id
-                                left outer join hierarchy subtask
-                                  on is_subtask(hierarchy, subtask)
+                                left outer join hierarchy subhierarchy
+                                  on is_subtask(hierarchy, subhierarchy)
+                                join task subtask
+                                  on subtask.hierarchy_id = subhierarchy.hierarchy_id
                               where
                                 hierarchy.denominator = 1
                               group by

--- a/test/dev/chrisreyes/task_tracker/persistence_test.clj
+++ b/test/dev/chrisreyes/task_tracker/persistence_test.clj
@@ -127,11 +127,17 @@
           hierarchy-id 11
           issue-link "http://some.url/1234"
           task-id 12
+          num-children 5
+          children-estimate 190
+          children-actual (* 2 children-estimate)
           db-row {:actual_time_minutes actual-time
                   :estimated_time_minutes estimated-time
                   :hierarchy_id hierarchy-id
                   :issue_link issue-link
-                  :task_id task-id}
+                  :task_id task-id
+                  :num_children num-children
+                  :children_estimated_time_minutes children-estimate
+                  :children_actual_time_minutes children-actual}
           task (persistence/db-row->task db-row)]
       (is (= (:actual-time-minutes task) actual-time)
           (str "Should have preserved the actual_time_minutes "
@@ -144,6 +150,19 @@
           "Should load the hierarchy_id into the hierarchy-node")
       (is (= (:issue-link task) issue-link)
           "Should have preserved the task_id into the task-id field")
+      (is (= (:num_children task) num-children)
+          (str "Should not have removed the num_children field even "
+               "though it is not in the schema"))
+      (is (= (:children_estimated_time_minutes task)
+             children-estimate)
+          (str "Should not have removed the "
+               ":children_estimated_time_minutes field even though it is "
+               "not in the schema"))
+      (is (= (:children_actual_time_minutes task)
+             children-actual)
+          (str "Should not have removed the "
+               ":children_actual_time_minutes field even though it is "
+               "not in the schema"))
       (is (= (:task-id task) task-id)
           "Should have preserved the task_id into the task-id field"))))
 


### PR DESCRIPTION
Implements #7 

Adds a `children_estimated_time_minutes` and `children_actual_time_minutes` to the return value of `persistence/get-all-roots`.

Also adds some utility functions to `core.clj` for now that help with manual testing.

![image](https://user-images.githubusercontent.com/13151450/68074069-45b3c400-fd54-11e9-8b43-e125ecc81860.png)
