### PR TITLE
#11 - Load project by ID

### DIFF
--- a/bin/start-server
+++ b/bin/start-server
@@ -6,31 +6,58 @@ IFS=$'\n\t';
 
 # Exit Codes
 readonly e_invalid_input=1;
+readonly e_no_tmp_dir=2;
+readonly e_no_cleanup=3;
 
 usage() {
     cat <<-USAGE
         Starts the local dev server. Not for use in production.
         
         usage: $0 [-h]
-            -h                                  Display this help text and return
+            -h                                  Display this help text and return.
         
         Relevant Environment Variables
             C17_TASKTRACKER_POSTGRES_SECRET     The name of the secret in AWS Secrets Manager
-                                                that contains the postgres connection information
+                                                that contains the postgres connection information.
 
         Dependencies
             init-postgres-container             A script to initialize the docker postgres container.
+            lein                                The executable for the leiningen build tool.
         
         Side Effects
             Starts 'docker-compose up' with the given values.
         
         Exit Codes
-            $e_invalid_input                                   Invalid input code
+            $e_invalid_input                                   Invalid input code.
+            $e_no_tmp_dir                                   Unable to create temporary directory for data backups.
+            $e_no_cleanup                                   Unable to clean up temporary directory.
 USAGE
 }
 
 readonly script_dir="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )";
 readonly project_dir="$(dirname $script_dir)";
+readonly tmp_dir=$(mktemp -d -t "$(basename $0)-$$-backup-data-directory.XXXXXXXX") || exit $e_no_tmp_dir;
+
+#=== FUNCTION ================================================================
+# NAME: cleanup
+# DESCRIPTION: Deletes temporary files. Should be called when script exits
+# PARAMETERS: None.
+# ENVIRONMENT VARIABLES: None.
+# DEPENDENCIES: None.
+# SIDE EFFECTS: None.
+# EXIT CODES: None.
+#=============================================================================
+cleanup() {
+    local status_code=0;
+    if [[ "$tmp_dir" != "/" ]]; then
+        rm -r $tmp_dir || status_code=$e_no_cleanup ;
+        if [[ $status_code -ne 0 ]]; then
+            echo "Unable to remove temp directory [$tmp_dir]" >&2;
+        fi
+    fi
+	return $status_code;
+}
+trap cleanup EXIT;
 
 main() {
     while getopts "h" opt; do
@@ -83,6 +110,44 @@ main() {
     local pgdata;
     read pgdata;
     pgdata=${pgdata:-${PGDATA:-}};
+
+    echo "Would you like to rebuild before deploying?";
+    echo -ne "\ty/n [n]: ";
+    local rebuild=;
+    read rebuild;
+
+    if [[ "$rebuild" == "y" ]]; then
+        echo -e "\tOkay, let's rebuild.";
+
+        local preserve_data=;
+        # Check if existing data exists
+        if [ -d $project_dir/target/data ] && [ "$(ls -a $project_dir/target/data)" ]; then
+            echo -e "\tDo you want to preserve the existing postgres data?";
+            echo -ne "\t\ty/n [y]: ";
+            read preserve_data;
+
+            if [[ "$preserve_data" != "n" ]]; then
+                echo -e "\t\tPreserving data";
+                cp -r $project_dir/target/data $tmp_dir/data;
+            fi
+
+            echo -e "\tStarting to rebuild";  # TODO
+        else
+            # There's no data to preserve
+            preserve_data="n";
+        fi
+
+        (
+            cd $project_dir;
+            lein uberjar;
+
+            docker-compose build;
+        )
+
+        if [[ "$preserve_data" != "n" ]]; then
+            cp -r $tmp_dir/data $project_dir/target/data;
+        fi
+    fi
 
     # Run all of this in a subshell so we can manipulate the environment variables
     (

--- a/bin/start-server
+++ b/bin/start-server
@@ -21,6 +21,7 @@ usage() {
                                                 that contains the postgres connection information.
 
         Dependencies
+            docker-compose
             init-postgres-container             A script to initialize the docker postgres container.
             lein                                The executable for the leiningen build tool.
         

--- a/src/dev/chrisreyes/task_tracker/core.clj
+++ b/src/dev/chrisreyes/task_tracker/core.clj
@@ -58,7 +58,7 @@
   [reason]
   {:status 400
    :headers {}
-   :body {:message reason}})
+   :body (json/write-str {:message reason})})
 
 (defn not-found-response
   "Generates a 404 response indicating the endpoint doesn't exist"

--- a/src/dev/chrisreyes/task_tracker/persistence.clj
+++ b/src/dev/chrisreyes/task_tracker/persistence.clj
@@ -27,7 +27,6 @@
             [clojure.set :refer [map-invert rename-keys]]
             [cognitect.aws.client.api :as aws]))
 
-
 (defn- filter-nil-values
   "Returns a map with only the key/value pairs of the original map where (some? value)"
   [original]
@@ -184,16 +183,16 @@
                                 hierarchy.next_sibling_denominator,
                                 hierarchy.next_sibling_numerator,
                                 hierarchy.numerator,
-                                count(subhierarchy.hierarchy_id) as num_children,
-                                sum(subtask.estimated_time_minutes) as children_estimated_time_minutes,
-                                sum(subtask.actual_time_minutes) as children_actual_time_minutes
+                                coalesce(count(subhierarchy.hierarchy_id), 0) as num_children,
+                                coalesce(sum(subtask.estimated_time_minutes), 0) as children_estimated_time_minutes,
+                                coalesce(sum(subtask.actual_time_minutes), 0) as children_actual_time_minutes
                               from
                                 hierarchy
                                 join task
                                   on hierarchy.hierarchy_id = task.hierarchy_id
                                 left outer join hierarchy subhierarchy
                                   on is_subtask(hierarchy, subhierarchy)
-                                join task subtask
+                                left outer join task subtask
                                   on subtask.hierarchy_id = subhierarchy.hierarchy_id
                               where
                                 hierarchy.denominator = 1
@@ -222,16 +221,16 @@
                                  hierarchy.next_sibling_denominator,
                                  hierarchy.next_sibling_numerator,
                                  hierarchy.numerator,
-                                 count(subhierarchy.hierarchy_id) as num_children,
-                                 sum(subtask.estimated_time_minutes) as children_estimated_time_minutes,
-                                 sum(subtask.actual_time_minutes) as children_actual_time_minutes
+                                 coalesce(count(subhierarchy.hierarchy_id), 0) as num_children,
+                                 coalesce(sum(subtask.estimated_time_minutes), 0) as children_estimated_time_minutes,
+                                 coalesce(sum(subtask.actual_time_minutes), 0) as children_actual_time_minutes
                                from
                                  hierarchy
                                  join task
                                    on hierarchy.hierarchy_id = task.hierarchy_id
                                  left outer join hierarchy subhierarchy
                                    on is_subtask(hierarchy, subhierarchy)
-                                 join task subtask
+                                 left outer join task subtask
                                    on subtask.hierarchy_id = subhierarchy.hierarchy_id
                                where
                                  task.task_id = ?

--- a/test/dev/chrisreyes/task_tracker/core_test.clj
+++ b/test/dev/chrisreyes/task_tracker/core_test.clj
@@ -86,6 +86,71 @@
               ; Note: This test will spuriously fail after the release of version 9000.0.1 (if that ever happens).
               "Should return a 404 status for future versions."))))))
 
+(deftest project-id-endpoint
+  (let [specific-task-id 17
+        specific-task {:task-id specific-task-id
+                       :issue-link "Some task"
+                       :hierarchy-node {:this-numerator 3
+                                        :this-denominator 5
+                                        :hierarchy-id 8}}]
+    (with-redefs [persistence/load-task-by-id (fn [config task-id]
+                                                (cond (not (= config "TEST-CONFIG"))
+                                                      "Did not stub out config!"
+                                                      (= task-id specific-task-id)
+                                                      specific-task
+                                                      :else nil))
+                  persistence/get-config (fn [secret]
+                                           (if (= secret "TEST-SECRET")
+                                             "TEST-CONFIG"
+                                             "Did not stub out secret!"))
+                  persistence/get-secret-from-aws (fn [secret-name]
+                                                    (if (= secret-name "TEST-SECRET-NAME")
+                                                      "TEST-SECRET"
+                                                      "Did not stub out secret name!"))
+                  persistence/get-credentials-secret (constantly "TEST-SECRET-NAME")]
+      (testing "/project/:id route"
+        (let [response (api-get backend-api (str "/v1.0.0/project/" specific-task-id))
+              status (:status response)
+              body (:body response)]
+          (is (<= 200 status 299) "Should return a 2XX status")
+          (is (= body (json/write-str specific-task))
+              "Should have returned a json string with the response of persistence/load-task-by-id")))
+      (testing "input validation"
+        (let [status-for-input #(:status (api-get backend-api
+                                                     (str "/v1.0.0/project/"
+                                                          %)))]
+          (is (= 400 (status-for-input "alpha"))
+              "Should return a 400 response for alphabetical task IDs")
+          (is (= 400 (status-for-input "1%3B%20drop%20table%20task%3B"))
+              "Should return a 400 response for attempted SQL injection")
+          (is (<= 200
+                  (status-for-input (str (inc (Integer/MAX_VALUE))))
+                  299)
+              "Should return a 2XX response even when using an ID greater
+               than the max integer value")
+          (is (<= 200
+                  (status-for-input "9223372036854775806")
+                  299)
+              "Should return a 2XX response even when using an ID less
+               than the max value for the bigint type in postgres")
+          (is (<= 200
+                  (status-for-input "9223372036854775807")
+                  299)
+              "Should return a 2XX response even when using an ID equal
+               to the max value for the bigint type in postgres")
+          (is (= 400 (status-for-input "9223372036854775808"))
+              "Should return a 400 response even when using an ID greater
+               than the max value for the bigint type in postgres")
+          (is (= 400 (status-for-input "-3"))
+              "Should return a 400 response for negative task IDs")))
+      (testing "versioning"
+        (let [response (api-get backend-api (str "/v1.0.0/project/" specific-task-id))
+              status (:status response)]
+          (is (<= 200 status 299) "Endpoint was introduced in v1.0.0. That version should still work"))
+        (let [response (api-get backend-api (str "/v0.9.0/project/" specific-task-id))
+              status (:status response)]
+          (is (= 404 status) "Endpoint was introduced in v1.0.0. Earlier versions should not work"))))))
+
 (deftest main-test
   (testing "Has main function"
     (is (some? -main) "Core should define a -main function")))

--- a/test/dev/chrisreyes/task_tracker/core_test.clj
+++ b/test/dev/chrisreyes/task_tracker/core_test.clj
@@ -116,9 +116,7 @@
           (is (= body (json/write-str specific-task))
               "Should have returned a json string with the response of persistence/load-task-by-id")))
       (testing "input validation"
-        (let [status-for-input #(:status (api-get backend-api
-                                                     (str "/v1.0.0/project/"
-                                                          %)))]
+        (let [status-for-input #(:status (api-get backend-api (str "/v1.0.0/project/" %)))]
           (is (= 400 (status-for-input "alpha"))
               "Should return a 400 response for alphabetical task IDs")
           (is (= 400 (status-for-input "1%3B%20drop%20table%20task%3B"))
@@ -131,7 +129,7 @@
           (is (<= 200
                   (status-for-input "9223372036854775806")
                   299)
-              "Should return a 2XX response even when using an ID less
+              "Should return a 2XX response when using an ID less
                than the max value for the bigint type in postgres")
           (is (<= 200
                   (status-for-input "9223372036854775807")
@@ -139,7 +137,7 @@
               "Should return a 2XX response even when using an ID equal
                to the max value for the bigint type in postgres")
           (is (= 400 (status-for-input "9223372036854775808"))
-              "Should return a 400 response even when using an ID greater
+              "Should return a 400 response when using an ID greater
                than the max value for the bigint type in postgres")
           (is (= 400 (status-for-input "-3"))
               "Should return a 400 response for negative task IDs")))


### PR DESCRIPTION
Implements another endpoint in #11 . This one gets task information by ID.

Also updates the startup script to have an option to rebuild with the newest code (and optionally to preserve existing postgres data).

Fixes an existing bug that wouldn't load tasks without child tasks.